### PR TITLE
feat: 대규모 트래픽 처리 & 운영 안정성 개선 (v1.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ docker-compose --env-file .env.dev up --build -d
 
 | 버전 | 주요 변경사항 |
 |------|-------------|
+| **v1.3.0** | [대규모 트래픽 처리 & 운영 안정성 개선](#-성능-개선-기록) — ALB Stickiness, Gemini Rate Limiting, HikariCP Fail Fast |
 | **v1.2.5** | [SSE 스트리밍 Network Error 수정](#-트러블슈팅-v125) — CORS 차단, 직접 fetch URL 프록시 전환 |
 | **v1.2.4** | [MCP 도구 실행 허위 성공 & 토큰 자동 갱신 수정](#-트러블슈팅-v124) — Gemini 허위 성공 응답, 401 토큰 갱신 실패 |
 | **v1.2.3** | [ECS Health Check 실패 수정](#-트러블슈팅-v123) — Alpine 이미지 curl 미포함, 컨테이너 반복 재시작 |
@@ -290,7 +291,42 @@ docker-compose --env-file .env.dev up --build -d
 
 <br>
 
-## 🔧 트러블슈팅 (v1.2.5)
+## � 성능 개선 기록
+
+> **Issue:** [#8 — 대규모 트래픽 처리 — ALB Stickiness, Gemini Rate Limiting, HikariCP Fail Fast](https://github.com/protove/MCP_calendar/issues/8)
+
+### Part 1: 대규모 트래픽 대응
+
+k6로 300 VU 부하 테스트를 실행해 Auto Scaling 발동을 확인하고,
+스케일 아웃 상황을 보며 Terraform 코드를 점검해
+잠재적 문제를 발굴했습니다.
+
+| 항목 | Before | After |
+|------|--------|-------|
+| ECS Auto Scaling | CPU 85% → Task 1→2 스케일 아웃 확인 | 동일 |
+| SSE 연결 안정성 | Stickiness 없어 Task 증가 시 끊김 가능 | lb_cookie Stickiness 적용으로 선제 해결 |
+
+### Part 2: 운영 안정성 개선
+
+코드 리뷰를 통해 발견한 잠재적 문제를 개선했습니다.
+
+| 문제 | 발견 방법 | 개선 내용 |
+|------|----------|----------|
+| Gemini Rate Limiting 없음 | GeminiService 코드 리뷰 | Redis 슬라이딩 윈도우 (분당 10회 / 일 50회) |
+| HikariCP timeout 30초 | application.yml 코드 리뷰 | 3초로 단축 (Fail Fast, 장애 전파 차단) |
+
+### 수정된 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `terraform/modules/compute-free-tier/main.tf` | ALB Target Group에 `lb_cookie` stickiness (3600초) 추가 |
+| `backend/.../service/RateLimitService.kt` | Redis Sorted Set 슬라이딩 윈도우 Rate Limiting 구현 |
+| `backend/.../service/ChatService.kt` | Rate Limit 체크 통합 (chat/chatStream) |
+| `backend/.../resources/application.yml` | HikariCP connection-timeout 30s → 3s |
+
+<br>
+
+## �🔧 트러블슈팅 (v1.2.5)
 
 > **Issue:** [#6 — SSE 스트리밍 채팅 Network Error — CORS 차단 및 직접 fetch URL 문제](https://github.com/protove/MCP_calendar/issues/6)
 

--- a/backend/src/main/kotlin/com/mcp/calendar/service/ChatService.kt
+++ b/backend/src/main/kotlin/com/mcp/calendar/service/ChatService.kt
@@ -4,6 +4,7 @@ import com.mcp.calendar.config.SystemPrompt
 import com.mcp.calendar.dto.request.*
 import com.mcp.calendar.dto.response.ChatResponse
 import com.mcp.calendar.dto.response.ChatStreamEvent
+import com.mcp.calendar.exception.GeminiRateLimitException
 import com.mcp.calendar.mcp.GeminiFunctionAdapter
 import com.mcp.calendar.mcp.McpToolRegistry
 import mu.KotlinLogging
@@ -27,7 +28,8 @@ class ChatService(
     private val geminiService: GeminiService,
     private val toolRegistry: McpToolRegistry,
     private val functionAdapter: GeminiFunctionAdapter,
-    private val conversationService: ConversationService
+    private val conversationService: ConversationService,
+    private val rateLimitService: RateLimitService
 ) {
 
     companion object {
@@ -36,6 +38,9 @@ class ChatService(
     }
 
     fun chat(userId: Long, message: String, conversationId: String?): ChatResponse {
+        // Rate Limit 확인
+        rateLimitService.checkAndIncrement(userId)?.let { throw GeminiRateLimitException(it) }
+
         val convId = conversationId ?: generateConversationId()
 
         logger.info { "Chat 시작 - userId: $userId, conversationId: $convId" }
@@ -173,6 +178,9 @@ class ChatService(
      * SSE 스트리밍 채팅 — Function Calling 루프를 포함하여 각 단계를 이벤트로 발행합니다.
      */
     fun chatStream(userId: Long, message: String, conversationId: String?): Flux<ChatStreamEvent> {
+        // Rate Limit 확인
+        rateLimitService.checkAndIncrement(userId)?.let { throw GeminiRateLimitException(it) }
+
         return Flux.create<ChatStreamEvent> { sink ->
             try {
                 val convId = conversationId ?: generateConversationId()

--- a/backend/src/main/kotlin/com/mcp/calendar/service/RateLimitService.kt
+++ b/backend/src/main/kotlin/com/mcp/calendar/service/RateLimitService.kt
@@ -1,0 +1,74 @@
+package com.mcp.calendar.service
+
+import mu.KotlinLogging
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Redis Sorted Set 슬라이딩 윈도우 방식 Rate Limiting
+ *
+ * - 분당 10회 / 일 50회 제한
+ * - Gemini 무료 등급 quota 보호: quota 소진 시 전체 사용자 장애 전파 방지
+ */
+@Service
+class RateLimitService(
+    private val redisTemplate: StringRedisTemplate
+) {
+
+    companion object {
+        private const val MINUTE_LIMIT = 10
+        private const val DAILY_LIMIT = 50
+        private val MINUTE_WINDOW = Duration.ofMinutes(1)
+        private val DAILY_WINDOW = Duration.ofDays(1)
+        private const val KEY_PREFIX = "rate_limit:chat:"
+    }
+
+    /**
+     * 요청 허용 여부를 확인하고, 허용 시 카운트를 증가시킵니다.
+     * @return 허용되면 null, 차단되면 에러 메시지 반환
+     */
+    fun checkAndIncrement(userId: Long): String? {
+        val now = Instant.now()
+        val nowMillis = now.toEpochMilli().toDouble()
+
+        // 분당 제한 확인
+        val minuteKey = "${KEY_PREFIX}minute:$userId"
+        val minuteCount = slidingWindowCount(minuteKey, now, MINUTE_WINDOW)
+        if (minuteCount >= MINUTE_LIMIT) {
+            logger.warn { "Rate limit exceeded (minute) - userId: $userId, count: $minuteCount" }
+            return "요청이 너무 많습니다. 1분 후 다시 시도해주세요. (분당 ${MINUTE_LIMIT}회 제한)"
+        }
+
+        // 일일 제한 확인
+        val dailyKey = "${KEY_PREFIX}daily:$userId"
+        val dailyCount = slidingWindowCount(dailyKey, now, DAILY_WINDOW)
+        if (dailyCount >= DAILY_LIMIT) {
+            logger.warn { "Rate limit exceeded (daily) - userId: $userId, count: $dailyCount" }
+            return "일일 요청 한도를 초과했습니다. 내일 다시 시도해주세요. (일 ${DAILY_LIMIT}회 제한)"
+        }
+
+        // 허용 → 두 키 모두 카운트 증가
+        redisTemplate.opsForZSet().add(minuteKey, "$nowMillis", nowMillis)
+        redisTemplate.expire(minuteKey, MINUTE_WINDOW.plusSeconds(10))
+
+        redisTemplate.opsForZSet().add(dailyKey, "$nowMillis", nowMillis)
+        redisTemplate.expire(dailyKey, DAILY_WINDOW.plusSeconds(60))
+
+        return null
+    }
+
+    private fun slidingWindowCount(key: String, now: Instant, window: Duration): Long {
+        val windowStart = now.minus(window).toEpochMilli().toDouble()
+        val nowMillis = now.toEpochMilli().toDouble()
+
+        // 윈도우 밖의 오래된 데이터 제거
+        redisTemplate.opsForZSet().removeRangeByScore(key, Double.NEGATIVE_INFINITY, windowStart)
+
+        // 현재 윈도우 내 요청 수 조회
+        return redisTemplate.opsForZSet().count(key, windowStart, nowMillis) ?: 0
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -46,7 +46,7 @@ spring:
     hikari:
       maximum-pool-size: 10
       minimum-idle: 5
-      connection-timeout: 30000
+      connection-timeout: 3000  # Fail Fast: DB 장애 시 빠른 실패로 장애 전파 차단
 
   data:
     redis:
@@ -92,7 +92,7 @@ spring:
     hikari:
       maximum-pool-size: 20
       minimum-idle: 10
-      connection-timeout: 30000
+      connection-timeout: 3000  # Fail Fast: DB 장애 시 빠른 실패로 장애 전파 차단
 
   data:
     redis:

--- a/terraform/modules/compute-free-tier/main.tf
+++ b/terraform/modules/compute-free-tier/main.tf
@@ -207,6 +207,13 @@ resource "aws_lb_target_group" "backend" {
     matcher             = "200"
   }
 
+  # SSE 스트리밍 연결 유지: Task 스케일 아웃 시 같은 Task로 라우팅
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 3600
+    enabled         = true
+  }
+
   tags = {
     Name        = "${var.project_name}-${var.environment}-backend-tg"
     Environment = var.environment


### PR DESCRIPTION
## 🚀 대규모 트래픽 처리 & 운영 안정성 개선 (v1.3.0)

Closes #8

### 변경 사항

#### Phase 1: ALB Stickiness 설정
- ALB Target Group에 `lb_cookie` stickiness 추가 (cookie_duration: 3600s)
- SSE 스트리밍 연결이 Scale-out 시에도 동일 인스턴스로 유지

#### Phase 2: Gemini Rate Limiting
- `RateLimitService` 신규 생성 (Redis Sorted Set 기반 Sliding Window)
- 분당 10회 / 일일 50회 사용자별 요청 제한
- `ChatService.chat()` 및 `chatStream()` 메서드에 Rate Limit 체크 통합

#### Phase 3: HikariCP Fail Fast
- DB Connection Timeout: 30초 → 3초로 축소
- DB 장애 시 빠른 실패로 쓰레드 블로킹 방지

### 수정된 파일
| 파일 | 변경 유형 |
|------|----------|
| `terraform/modules/compute-free-tier/main.tf` | ALB Stickiness 추가 |
| `backend/.../service/RateLimitService.kt` | 신규 생성 |
| `backend/.../service/ChatService.kt` | Rate Limit 통합 |
| `backend/.../resources/application.yml` | HikariCP timeout 변경 |
| `README.md` | v1.3.0 문서 업데이트 |

### 테스트
- [x] Docker 빌드 성공 (v1.3.0)
- [x] ECR 푸시 완료
- [x] ECS 배포 안정화 확인 (services-stable)
- [x] ALB 헬스 체크 통과